### PR TITLE
Implementing the development option

### DIFF
--- a/nodestream_plugin_k8s/commands/list_command.py
+++ b/nodestream_plugin_k8s/commands/list_command.py
@@ -3,6 +3,7 @@ from typing import Iterable
 
 from nodestream.cli import NodestreamCommand
 from nodestream.cli.commands.shared_options import (
+    DEVELOPMENT_ENVIRONMENT_OPTION,
     JSON_OPTION,
     PROJECT_FILE_OPTION,
     SCOPE_NAME_OPTION,
@@ -14,7 +15,12 @@ from ..project_resource_manager import PipelineDesiredState, ProjectResourceMana
 class ListCommand(NodestreamCommand):
     name = "k8s list"
     description = "List Nodestream Pipelines Under Kubernetes Management"
-    options = [PROJECT_FILE_OPTION, SCOPE_NAME_OPTION, JSON_OPTION]
+    options = [
+        PROJECT_FILE_OPTION,
+        SCOPE_NAME_OPTION,
+        JSON_OPTION,
+        DEVELOPMENT_ENVIRONMENT_OPTION,
+    ]
 
     def display_as_table(self, items_to_display: Iterable[PipelineDesiredState]):
         fields = PipelineDesiredState.field_names()
@@ -33,6 +39,14 @@ class ListCommand(NodestreamCommand):
         )
         self.line(json_string)
 
+    def add_development_args(self, items_to_display):
+        for item in items_to_display:
+            item.perpetual_concurrency = (
+                item.perpetual_concurrency if item.debug_enabled else 0
+            )
+            item.suspend = False if item.debug_enabled else True
+            yield item
+
     async def handle_async(self):
         project_manager = ProjectResourceManager(self.get_project())
         scope_name = self.option(SCOPE_NAME_OPTION.name)
@@ -40,6 +54,10 @@ class ListCommand(NodestreamCommand):
             mgr.desired_state
             for mgr in project_manager.get_managed_pipelines(scope_name)
         )
+        development_environment = self.option(DEVELOPMENT_ENVIRONMENT_OPTION.name)
+        if development_environment:
+            items_to_display = self.add_development_args(items_to_display)
+
         use_json = self.option(JSON_OPTION.name)
         render_method = self.display_as_json if use_json else self.display_as_table
         render_method(items_to_display)

--- a/nodestream_plugin_k8s/project_resource_manager.py
+++ b/nodestream_plugin_k8s/project_resource_manager.py
@@ -5,10 +5,12 @@ from nodestream.project import PipelineDefinition, Project
 
 CRON_SCHEDULE_ANNOTATION_NAME = "nodestream_plugin_k8s_schedule"
 PERPETUAL_CONCURRENCY_ANNOTATION_NAME = "nodestream_plugin_k8s_conccurency"
+DEBUG_ANNOTATION_NAME = "nodestream_plugin_k8s_debug"
 
 KUBERNETES_MANAGEMENT_ANNOTATIONS = {
     CRON_SCHEDULE_ANNOTATION_NAME,
     PERPETUAL_CONCURRENCY_ANNOTATION_NAME,
+    DEBUG_ANNOTATION_NAME,
 }
 
 
@@ -17,6 +19,8 @@ class PipelineDesiredState:
     pipeline_name: str
     cron_schedule: Optional[str] = None
     perpetual_concurrency: Optional[int] = None
+    debug_enabled: Optional[bool] = False
+    suspend: Optional[bool] = False
 
     @classmethod
     def field_names(cls) -> List[str]:
@@ -40,13 +44,22 @@ class PipelineResourceManager:
         cron_schedule = self.definition.configuration.effective_annotations.get(
             CRON_SCHEDULE_ANNOTATION_NAME
         )
+
         perpetual_concurrency = self.definition.configuration.effective_annotations.get(
             PERPETUAL_CONCURRENCY_ANNOTATION_NAME
         )
+        debug_enabled = (
+            self.definition.configuration.effective_annotations.get(
+                DEBUG_ANNOTATION_NAME
+            )
+            or False
+        )
+
         return PipelineDesiredState(
             pipeline_name=self.definition.name,
             cron_schedule=cron_schedule,
             perpetual_concurrency=perpetual_concurrency,
+            debug_enabled=debug_enabled,
         )
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -691,6 +691,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -765,32 +775,34 @@ pyarrow = ["pyarrow (>=1.0.0)"]
 
 [[package]]
 name = "nodestream"
-version = "0.11.0"
+version = "0.11.8"
 description = "A Fast, Declarative ETL for Graph Databases."
 optional = false
-python-versions = ">=3.10,<4.0"
-files = [
-    {file = "nodestream-0.11.0-py3-none-any.whl", hash = "sha256:34e1714c99bf44e4c845193ef26e29d0abac51f330c830f8bfe26b082d347669"},
-    {file = "nodestream-0.11.0.tar.gz", hash = "sha256:c2d3ec3de84f9b2b559c5d905cd7d083762889654ad819963c6364368f5c39c5"},
-]
+python-versions = "^3.10"
+files = []
+develop = true
 
 [package.dependencies]
-boto3 = ">=1.26.137,<2.0.0"
-cleo = ">=2.0.1,<3.0.0"
-confluent-kafka = ">=2.3.0,<3.0.0"
-cookiecutter = ">=2.1.1,<3.0.0"
+boto3 = "^1.26.137"
+cleo = "^2.0.1"
+confluent-kafka = "^2.3.0"
+cookiecutter = "^2.1.1"
 cymple = "0.8.1"
-httpx = ">=0.24.1,<0.25.0"
-Jinja2 = ">=3,<4"
-jmespath = ">=1.0.1,<2.0.0"
-neo4j = ">=5.8.0,<6.0.0"
-pandas = ">=2,<3"
-psutil = ">=5.9.6,<6.0.0"
-python-json-logger = ">=2.0.4,<3.0.0"
-pyyaml = ">=6.0,<7.0"
-schema = ">=0.7.5,<0.8.0"
-testcontainers = {version = ">=3.7.1,<4.0.0", extras = ["neo4j"]}
+httpx = "^0.24.1"
+Jinja2 = "^3"
+jmespath = "^1.0.1"
+neo4j = "^5.8.0"
+pandas = "^2"
+psutil = "^5.9.6"
+python-json-logger = "^2.0.4"
+pyyaml = "^6.0"
+schema = "^0.7.5"
+testcontainers = {version = "^3.7.1", extras = ["neo4j"]}
 uvloop = {version = ">=0.17.0,<=0.18.0", markers = "sys_platform == \"darwin\" or sys_platform == \"linux\""}
+
+[package.source]
+type = "directory"
+url = "../nodestream"
 
 [[package]]
 name = "numpy"
@@ -1023,6 +1035,24 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-asyncio"
+version = "0.21.1"
+description = "Pytest support for asyncio"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-asyncio-0.21.1.tar.gz", hash = "sha256:40a7eae6dded22c7b604986855ea48400ab15b069ae38116e8c01238e9eeb64d"},
+    {file = "pytest_asyncio-0.21.1-py3-none-any.whl", hash = "sha256:8666c1c8ac02631d7c51ba282e0c69a8a452b211ffedf2599099845da5c5c37b"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+
+[package.extras]
+docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1.0)"]
+testing = ["coverage (>=6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (>=0.931)", "pytest-trio (>=0.7.0)"]
+
+[[package]]
 name = "pytest-cov"
 version = "4.1.0"
 description = "Pytest plugin for measuring coverage."
@@ -1128,6 +1158,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -1135,8 +1166,15 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -1153,6 +1191,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -1160,6 +1199,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -1622,4 +1662,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "2cbb9cac80153475df76b92d280fd2e0b97361c8f65ec705090c06eec5817c3c"
+content-hash = "99fc23b28444be5e6f12b2077780198ed0813ed7c87e04a89be90eca22908886"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,8 @@ license = "Apache 2.0"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-nodestream = "^0.11.0"
+# nodestream = "^0.11.0"
+nodestream = {path = "../nodestream", develop = true }
 
 [tool.poetry.plugins."nodestream.plugins"]
 commands = "nodestream_plugin_k8s.commands"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,7 @@ license = "Apache 2.0"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-# nodestream = "^0.11.0"
-nodestream = {path = "../nodestream", develop = true }
+nodestream = "^0.11.9"
 
 [tool.poetry.plugins."nodestream.plugins"]
 commands = "nodestream_plugin_k8s.commands"

--- a/tests/test_list_command.py
+++ b/tests/test_list_command.py
@@ -1,0 +1,148 @@
+from unittest.mock import MagicMock
+
+import pytest
+from nodestream.project import (
+    PipelineConfiguration,
+    PipelineDefinition,
+    PipelineScope,
+    Project,
+)
+
+from nodestream_plugin_k8s.commands import ListCommand
+
+
+@pytest.fixture
+def project():
+    return Project(
+        scopes_by_name={
+            "crons": PipelineScope(
+                name="crons",
+                pipelines_by_name={
+                    "test_cron_pipeline_a": PipelineDefinition(
+                        name="test_cron_pipeline_a",
+                        file_path="crons/test_cron_pipeline_a",
+                        configuration=PipelineConfiguration(
+                            annotations={
+                                "nodestream_plugin_k8s_schedule": "*/5 * * * *",
+                                "nodestream_plugin_k8s_debug": True,
+                            },
+                        ),
+                    ),
+                    "test_cron_pipeline_b": PipelineDefinition(
+                        name="test_cron_pipeline_b",
+                        file_path="crons/test_cron_pipeline_b",
+                        configuration=PipelineConfiguration(
+                            annotations={
+                                "nodestream_plugin_k8s_schedule": "*/5 * * * *",
+                            }
+                        ),
+                    ),
+                },
+            ),
+            "perpetual": PipelineScope(
+                name="perpetual",
+                pipelines_by_name={
+                    "test_perpetual_pipeline_a": PipelineDefinition(
+                        name="test_perpetual_pipeline_a",
+                        file_path="perpetual/test_perpetual_pipeline_a",
+                        configuration=PipelineConfiguration(
+                            annotations={
+                                "nodestream_plugin_k8s_conccurency": 4,
+                                "nodestream_plugin_k8s_debug": True,
+                            },
+                        ),
+                    ),
+                    "test_perpetual_pipeline_b": PipelineDefinition(
+                        name="test_perpetual_pipeline_b",
+                        file_path="perpetual/test_perpetual_pipeline_b",
+                        configuration=PipelineConfiguration(
+                            annotations={
+                                "nodestream_plugin_k8s_conccurency": 4,
+                            }
+                        ),
+                    ),
+                },
+            ),
+        }
+    )
+
+
+@pytest.fixture
+def subject():
+    return ListCommand()
+
+
+TEST_JSON_NO_DEBUG = [
+    {
+        "pipeline_name": "test_cron_pipeline_a",
+        "cron_schedule": "*/5 * * * *",
+        "perpetual_concurrency": None,
+        "suspend": False,
+        "debug_enabled": True,
+    },
+    {
+        "pipeline_name": "test_cron_pipeline_b",
+        "cron_schedule": "*/5 * * * *",
+        "perpetual_concurrency": None,
+        "suspend": False,
+        "debug_enabled": False,
+    },
+]
+
+
+TEST_JSON_DEBUG = [
+    {
+        "pipeline_name": "test_perpetual_pipeline_a",
+        "cron_schedule": None,
+        "perpetual_concurrency": 4,
+        "suspend": False,
+        "debug_enabled": True,
+    },
+    {
+        "pipeline_name": "test_perpetual_pipeline_b",
+        "cron_schedule": None,
+        "perpetual_concurrency": 0,
+        "suspend": True,
+        "debug_enabled": False,
+    },
+]
+
+
+"""
+nodestream k8s list --scope crons --json
+"""
+
+
+@pytest.mark.asyncio
+async def test_no_debug(project: Project, subject: ListCommand):
+    def options_mock(option):
+        options = {"scope": "crons", "json": True, "development": False}
+        return options[option]
+
+    subject.get_project = MagicMock(return_value=project)
+    subject.display_as_json = MagicMock()
+    subject.option = MagicMock(side_effect=options_mock)
+    await subject.handle_async()
+    results = subject.display_as_json.call_args[0][0]
+    results = [result.as_dict() for result in results]
+    assert results == TEST_JSON_NO_DEBUG
+
+
+"""
+nodestream k8s list --scope perpetual --json --development
+"""
+
+
+@pytest.mark.asyncio
+async def test_debug(project: Project, subject: ListCommand):
+    def options_mock(option):
+        options = {"scope": "perpetual", "json": True, "development": True}
+        return options[option]
+
+    subject.get_project = MagicMock(return_value=project)
+    subject.display_as_json = MagicMock()
+    subject.option = MagicMock(side_effect=options_mock)
+    await subject.handle_async()
+    results = subject.display_as_json.call_args[0][0]
+    results = [result.as_dict() for result in results]
+    assert results == TEST_JSON_DEBUG


### PR DESCRIPTION
This PR adds the option to overwrite the time-to-live configurations provided to have a fixed expiry in hours for all types. This is useful solely for debugging. For instance, if in a development environment we would want a ttl pipeline that deleted everything immediately. 